### PR TITLE
Make prefersReducedMotion SSR-safe with lazy initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,21 +160,22 @@ Properly managing ARIA states and focus trapping requires careful coordination o
 
 ---
 
-### `prefersReducedMotion`
+### `prefersReducedMotion()`
 
-Boolean value indicating user's motion preference.
+A utility function that 1) toggles a CSS class (`prm`) on the body tag based on the system's reduced motion setting, and 2) returns the the current reduced motion setting's value.
 
-**Type:** `boolean`
+**Type:** `() => boolean`
 
 **Behavior:**
-- Automatically updates based on `(prefers-reduced-motion: reduce)` media query
-- Adds/removes `prm` class on `document.body`  
-- Updates when user changes system preferences
+- SSR-safe with lazy initialization (only accesses `window` when first called)
+- Returns current value based on `(prefers-reduced-motion: reduce)` media query
+- Adds/removes `prm` class on `document.body`
+- Automatically updates when user changes system preferences
 
 **Example:**
 ```typescript
 // Check preference
-if (prefersReducedMotion) {
+if (prefersReducedMotion()) {
   // Skip or reduce animations
   element.style.transition = 'none';
 } else {
@@ -193,8 +194,8 @@ body.prm .animated {
 }
 ```
 
-**Why use `prefersReducedMotion`?**
-Respecting user motion preferences is crucial for accessibility, particularly for users with vestibular disorders. This provides an easy way to conditionally disable animations.
+**Why use `prefersReducedMotion()`?**
+Respecting user motion preferences is crucial for accessibility, particularly for users with vestibular disorders. This provides an easy, SSR-safe way to conditionally disable animations.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Essential JavaScript utilities that empower modern accessibility
 
-A11yKit is a lightweight, JS accessibility (a11y) library that provides essential utilities for managing focus,  announcing screen reader (SR) messages, hiding content from SR's, and managing motion/animation preferences. Built with modern web development in mind, it offers a clean API with full type safety and comprehensive browser support.
+A11yKit is a lightweight, JS accessibility (a11y) library that provides essential UI utilities for managing focus, announcing screen reader (SR) messages, hiding content from SR's, and managing motion/animation preferences. Built with modern web development in mind, it offers a clean API with full type safety and comprehensive browser support.
 
 ## Features
 
@@ -18,13 +18,13 @@ A11yKit is a lightweight, JS accessibility (a11y) library that provides essentia
 - ⚡ **Lightweight** - Minimal footprint, no dependencies
 - ✅ **Well Tested** - Comprehensive Jest test suite with 97%+ coverage
 
-## Why does a11ykit exist?
+## Why does A11yKit exist?
 
 When auditing web sites for accessibility compliance, I often find well-meaning attempts to make the experience more accessible, but they are often ad-hoc, one-off fixes that clutter the HTML with unnecessary, redundant, and even detrimental code. Examples:
 - Harcoded `tabindex` attributes on elements that should not be focusable
-- Overzealous and unmanagable use of `aria-live` that creates a broken experience
+- Overzealous and unmanageable use of `aria-live` that creates a broken experience
 
-I firmly believe that accessibility solutions should be simple and elegant, minimze code clutter (and potential for future issues), and rely on a foundation of semantic HTML and minimal  `aria-*` and `role` attributes to improve the accessible experience. A11ykit provides a set of tools that makes managing announcing important messages to SR users and managing focus easy and manageable.
+I firmly believe that accessibility solutions should be simple and elegant, minimze code clutter (and potential for future issues), and rely on a foundation of semantic HTML and minimal  `aria-*` and `role` attributes to improve the accessible experience. A11yKit provides a set of tools that makes managing announcing important messages to SR users and managing focus easy and manageable.
 
 With that said - A11yKit is not a cure-all for your accessibility challenges.  While the goal of A11yKit is to make these techniques easier to manage, missuse can lead to an inaccessible experience. Use these functions minimally and with great care - and **always test your experiences using screen readers**.
 
@@ -37,7 +37,7 @@ npm install @a11yfox/a11ykit
 ```
 
 ```js
-import { access, announce, ariaHide, ariaUnhide, prefersReducedMotion } from 'a11ykit';
+import { access, announce, ariaHide, ariaUnhide, prefersReducedMotion } from '@a11yfox/a11ykit';
 ```
 
 ## API Reference
@@ -162,7 +162,7 @@ Properly managing ARIA states and focus trapping requires careful coordination o
 
 ### `prefersReducedMotion()`
 
-A utility function that 1) toggles a CSS class (`prm`) on the body tag based on the system's reduced motion setting, and 2) returns the the current reduced motion setting's value.
+A utility function that 1) toggles a CSS class (`prm`) on the body tag based on the system's reduced motion setting, and 2) returns the the current reduced motion setting's value. The function also creates a change event listener that updates the `prm` class dynamically.
 
 **Type:** `() => boolean`
 
@@ -184,6 +184,7 @@ if (prefersReducedMotion()) {
 }
 
 // Or use CSS with the body class
+// NOTE: the .prm class won't be added until prefersReducedMotion() is called
 /* In CSS */
 .animated {
   transition: transform 0.3s ease;

--- a/README.md
+++ b/README.md
@@ -184,15 +184,23 @@ if (prefersReducedMotion()) {
 }
 
 // Or use CSS with the body class
-// NOTE: the .prm class won't be added until prefersReducedMotion() is called
-/* In CSS */
+// NOTE: the .prm class won't be added until prefersReducedMotion() is called, preferably on DOMContentLoaded
+
+// Initialize when DOM is ready to enable the CSS approach
+document.addEventListener('DOMContentLoaded', () => {
+  prefersReducedMotion();
+});
+
+/* In CSS, create your animations: */
 .animated {
   transition: transform 0.3s ease;
 }
 
+/* ...and reset/disable them when the .prm class is present: */
 body.prm .animated {
   transition: none;
 }
+
 ```
 
 **Why use `prefersReducedMotion()`?**

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "npm run test && rollup -c",
     "build:watch": "rollup -c -w",
     "build:only": "rollup -c",
+    "build:debug": "DEBUG_BUILD=true rollup -c",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
@@ -36,8 +37,6 @@
     "a11y",
     "frontend",
     "typescript",
-    "focus",
-    "aria",
     "screen-reader"
   ],
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a11yfox/a11ykit",
-  "version": "1.0.3",
+  "version": "1.0.4-beta.0",
   "description": "A set of utilities that empower modern accessibility.",
   "main": "dist/a11ykit.umd.js",
   "module": "dist/a11ykit.esm.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import typescript from '@rollup/plugin-typescript';
 import terser from '@rollup/plugin-terser';
 
 const production = !process.env.ROLLUP_WATCH;
+const debugBuild = process.env.DEBUG_BUILD === 'true';
 
 export default [
   // ES Module build
@@ -27,7 +28,7 @@ export default [
         target: 'es2018',
         module: 'esnext'
       }),
-      production && terser()
+      production && !debugBuild && terser()
     ].filter(Boolean)
   },
   // UMD build for browsers
@@ -50,7 +51,7 @@ export default [
         target: 'es5',
         module: 'ESNext'
       }),
-      production && terser()
+      production && !debugBuild && terser()
     ].filter(Boolean)
   },
   // Minified UMD build

--- a/src/prefers-reduced-motion.ts
+++ b/src/prefers-reduced-motion.ts
@@ -1,20 +1,28 @@
-let prefersReducedMotion: boolean;
+let _prefersReducedMotion: boolean = false;
+let _initialized: boolean = false;
 
-const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
-
-function prmTest(e: MediaQueryListEvent | MediaQueryList | boolean): void {
-  const prm = e === true || (typeof e === 'object' && 'matches' in e && e.matches === true);
-  const dbc = document.body.classList;
-  if (prm) {
-    dbc.add('prm');
-  } else {
-    dbc.remove('prm');
-  }
-  prefersReducedMotion = prm;
+function setBodyClass(matches: boolean): void {
+  document.body.classList.toggle('prm', matches);
 }
 
-mql.addEventListener('change', prmTest);
+function updatePRM(e: MediaQueryListEvent): void {
+  _prefersReducedMotion = e.matches;
+  setBodyClass(_prefersReducedMotion);
+}
 
-prmTest(mql);
+function prefersReducedMotion(): boolean {
+  if (!_initialized) {
+    _initialized = true;
+
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    _prefersReducedMotion = mql.matches;
+
+    mql.addEventListener('change', updatePRM);
+
+    setBodyClass(_prefersReducedMotion);
+  }
+
+  return _prefersReducedMotion;
+}
 
 export { prefersReducedMotion };

--- a/tests/prefers-reduced-motion.test.ts
+++ b/tests/prefers-reduced-motion.test.ts
@@ -37,27 +37,53 @@ describe('prefers-reduced-motion', () => {
   });
 
   describe('initialization', () => {
-    test('calls matchMedia with correct query on module load', () => {
-      // Re-import to trigger initialization
+    test('does not call matchMedia until function is called (SSR-safe)', () => {
       jest.resetModules();
       require('../src/prefers-reduced-motion');
-      
+
+      // matchMedia should not be called on module load
+      expect(mockMatchMedia).not.toHaveBeenCalled();
+    });
+
+    test('calls matchMedia with correct query on first function call', () => {
+      jest.resetModules();
+      const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+
+      // Call the function to trigger initialization
+      prefersReducedMotion();
+
       expect(mockMatchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
     });
 
-    test('adds event listener for media query changes', () => {
+    test('adds event listener for media query changes on first call', () => {
       jest.resetModules();
-      require('../src/prefers-reduced-motion');
-      
+      const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+
+      prefersReducedMotion();
+
       expect(mockMediaQueryList.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
     });
 
-    test('runs initial test on module load', () => {
-      document.body.className = '';
-      
+    test('only initializes once even with multiple calls', () => {
       jest.resetModules();
-      require('../src/prefers-reduced-motion');
-      
+      const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+
+      prefersReducedMotion();
+      prefersReducedMotion();
+      prefersReducedMotion();
+
+      expect(mockMatchMedia).toHaveBeenCalledTimes(1);
+      expect(mockMediaQueryList.addEventListener).toHaveBeenCalledTimes(1);
+    });
+
+    test('applies initial body class on first function call', () => {
+      document.body.className = '';
+
+      jest.resetModules();
+      const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+
+      prefersReducedMotion();
+
       // Since mockMediaQueryList.matches is false, no 'prm' class should be added
       expect(document.body.classList.contains('prm')).toBe(false);
     });
@@ -66,59 +92,67 @@ describe('prefers-reduced-motion', () => {
   describe('media query handling', () => {
     test('adds prm class when prefers-reduced-motion is enabled', () => {
       mockMediaQueryList.matches = true;
-      
+
       jest.resetModules();
       const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
-      
+
+      const result = prefersReducedMotion();
+
       expect(document.body.classList.contains('prm')).toBe(true);
-      expect(prefersReducedMotion).toBe(true);
+      expect(result).toBe(true);
     });
 
     test('does not add prm class when prefers-reduced-motion is disabled', () => {
       mockMediaQueryList.matches = false;
-      
+
       jest.resetModules();
       const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
-      
+
+      const result = prefersReducedMotion();
+
       expect(document.body.classList.contains('prm')).toBe(false);
-      expect(prefersReducedMotion).toBe(false);
+      expect(result).toBe(false);
     });
 
     test('removes prm class when preference changes from enabled to disabled', () => {
       // Start with reduced motion enabled
       mockMediaQueryList.matches = true;
-      
+
       jest.resetModules();
-      require('../src/prefers-reduced-motion');
-      
+      const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+
+      prefersReducedMotion();
+
       expect(document.body.classList.contains('prm')).toBe(true);
-      
+
       // Simulate change event with reduced motion disabled
       const changeHandler = mockMediaQueryList.addEventListener.mock.calls
         .find((call: any[]) => call[0] === 'change')[1];
-      
+
       const mockEvent = { matches: false };
       changeHandler(mockEvent);
-      
+
       expect(document.body.classList.contains('prm')).toBe(false);
     });
 
     test('adds prm class when preference changes from disabled to enabled', () => {
       // Start with reduced motion disabled
       mockMediaQueryList.matches = false;
-      
+
       jest.resetModules();
-      require('../src/prefers-reduced-motion');
-      
+      const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+
+      prefersReducedMotion();
+
       expect(document.body.classList.contains('prm')).toBe(false);
-      
+
       // Simulate change event with reduced motion enabled
       const changeHandler = mockMediaQueryList.addEventListener.mock.calls
         .find((call: any[]) => call[0] === 'change')[1];
-      
+
       const mockEvent = { matches: true };
       changeHandler(mockEvent);
-      
+
       expect(document.body.classList.contains('prm')).toBe(true);
     });
   });
@@ -126,34 +160,30 @@ describe('prefers-reduced-motion', () => {
   describe('prefersReducedMotion export value', () => {
     test('reflects current reduced motion preference', () => {
       mockMediaQueryList.matches = true;
-      
+
       jest.resetModules();
       const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
-      
-      expect(prefersReducedMotion).toBe(true);
+
+      expect(prefersReducedMotion()).toBe(true);
     });
 
     test('updates when preference changes', () => {
       // Start disabled
       mockMediaQueryList.matches = false;
-      
+
       jest.resetModules();
-      let { prefersReducedMotion } = require('../src/prefers-reduced-motion');
-      
-      expect(prefersReducedMotion).toBe(false);
-      
+      const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+
+      expect(prefersReducedMotion()).toBe(false);
+
       // Trigger change to enabled
       const changeHandler = mockMediaQueryList.addEventListener.mock.calls
         .find((call: any[]) => call[0] === 'change')[1];
-      
+
       changeHandler({ matches: true });
-      
-      // Re-import to get updated value
-      jest.resetModules();
-      ({ prefersReducedMotion } = require('../src/prefers-reduced-motion'));
-      
-      // Note: The exported value is set at module initialization time
-      // In a real scenario, you'd typically access this through a function
+
+      // Function should return updated value without re-import
+      expect(prefersReducedMotion()).toBe(true);
     });
   });
 
@@ -166,51 +196,48 @@ describe('prefers-reduced-motion', () => {
 
       expect(() => {
         jest.resetModules();
-        require('../src/prefers-reduced-motion');
+        const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+        prefersReducedMotion();
       }).toThrow();
     });
 
-    test('handles event object variations', () => {
+    test('handles MediaQueryListEvent with matches property', () => {
       jest.resetModules();
-      require('../src/prefers-reduced-motion');
-      
+      const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+
+      prefersReducedMotion();
+
       const changeHandler = mockMediaQueryList.addEventListener.mock.calls
         .find((call: any[]) => call[0] === 'change')[1];
-      
-      // Test with boolean true
-      changeHandler(true);
-      expect(document.body.classList.contains('prm')).toBe(true);
-      
-      // Test with boolean false
-      changeHandler(false);
-      expect(document.body.classList.contains('prm')).toBe(false);
-      
-      // Test with object without matches property
-      changeHandler({});
-      expect(document.body.classList.contains('prm')).toBe(false);
-      
-      // Test with object with matches: true
+
+      // Test with matches: true
       changeHandler({ matches: true });
       expect(document.body.classList.contains('prm')).toBe(true);
+
+      // Test with matches: false
+      changeHandler({ matches: false });
+      expect(document.body.classList.contains('prm')).toBe(false);
     });
 
     test('preserves other classes on document.body', () => {
       document.body.className = 'existing-class another-class';
-      
+
       mockMediaQueryList.matches = true;
       jest.resetModules();
-      require('../src/prefers-reduced-motion');
-      
+      const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+
+      prefersReducedMotion();
+
       expect(document.body.classList.contains('existing-class')).toBe(true);
       expect(document.body.classList.contains('another-class')).toBe(true);
       expect(document.body.classList.contains('prm')).toBe(true);
-      
+
       // Test removal doesn't affect other classes
       const changeHandler = mockMediaQueryList.addEventListener.mock.calls
         .find((call: any[]) => call[0] === 'change')[1];
-      
+
       changeHandler({ matches: false });
-      
+
       expect(document.body.classList.contains('existing-class')).toBe(true);
       expect(document.body.classList.contains('another-class')).toBe(true);
       expect(document.body.classList.contains('prm')).toBe(false);
@@ -220,19 +247,21 @@ describe('prefers-reduced-motion', () => {
   describe('CSS class management', () => {
     test('toggles prm class correctly', () => {
       jest.resetModules();
-      require('../src/prefers-reduced-motion');
-      
+      const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+
+      prefersReducedMotion();
+
       const changeHandler = mockMediaQueryList.addEventListener.mock.calls
         .find((call: any[]) => call[0] === 'change')[1];
-      
+
       // Enable reduced motion
       changeHandler({ matches: true });
       expect(document.body.classList.contains('prm')).toBe(true);
-      
+
       // Disable reduced motion
       changeHandler({ matches: false });
       expect(document.body.classList.contains('prm')).toBe(false);
-      
+
       // Enable again
       changeHandler({ matches: true });
       expect(document.body.classList.contains('prm')).toBe(true);
@@ -240,17 +269,19 @@ describe('prefers-reduced-motion', () => {
 
     test('handles multiple rapid changes', () => {
       jest.resetModules();
-      require('../src/prefers-reduced-motion');
-      
+      const { prefersReducedMotion } = require('../src/prefers-reduced-motion');
+
+      prefersReducedMotion();
+
       const changeHandler = mockMediaQueryList.addEventListener.mock.calls
         .find((call: any[]) => call[0] === 'change')[1];
-      
+
       // Rapid changes
       changeHandler({ matches: true });
       changeHandler({ matches: false });
       changeHandler({ matches: true });
       changeHandler({ matches: false });
-      
+
       expect(document.body.classList.contains('prm')).toBe(false);
     });
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2018",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2018", "DOM"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## Summary

This PR refactors `prefersReducedMotion` from a boolean value to a function that returns a boolean, making it safe to use in Server-Side Rendering (SSR) environments like Nuxt.js.

### Key Changes

- **SSR-Safe Lazy Initialization**: No `window` access at module import time - only initializes when first called
- **API Change**: `prefersReducedMotion` → `prefersReducedMotion()` (function call)
- **Code Improvements**: 
  - Added `setBodyClass()` utility to eliminate code duplication
  - Simplified `updatePRM()` by removing unnecessary type guards
  - Cleaner, more maintainable code overall
- **Updated Documentation**: README now reflects function-based API and SSR-safety
- **Build Tooling**: Added `build:debug` script for unminified builds

### Behavior Preserved

- Still automatically toggles `prm` class on `document.body`
- Still listens for media query changes and updates in real-time
- All 70 tests pass

### Breaking Change

This is a **breaking change** for users who currently access `prefersReducedMotion` as a value. They'll need to update to call it as a function: `prefersReducedMotion()`.

Recommend publishing as a beta version first: `npm publish --tag beta`

## Test Plan

- [x] All existing tests pass (70/70)
- [x] Added SSR-safety test (verifies no window access on module load)
- [x] Build succeeds with all three output formats
- [x] Updated tests to use function-based API
- [ ] Manual testing in Nuxt.js/SSR environment (should be tested after beta release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)